### PR TITLE
fix(email): add receiver field to email log

### DIFF
--- a/src/lib/api/routers/email.router.ts
+++ b/src/lib/api/routers/email.router.ts
@@ -50,6 +50,7 @@ emailRouter.post("/", zValidator("json", EmailBodySchema), async (c) => {
 
   await createLog(
     JSON.stringify({
+      receiver: body.to,
       subject: body.subject,
       messageId: response.messageId,
     })


### PR DESCRIPTION
The receiver (to) field was missing from the email log, making it difficult to track which emails were sent to which recipients. This change adds the receiver field to the log output for better auditability.