### PR TITLE
ci(github): use secrets instead of vars for EMAIL_PASSWORD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       EMAIL_USER: ${{ vars.EMAIL_USER }}
-      EMAIL_PASSWORD: ${{ vars.EMAIL_PASSWORD }}
+      EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
 
     steps:
       - name: Checkout code 🛎️


### PR DESCRIPTION
The EMAIL_PASSWORD should be stored in secrets rather than variables for better security. This change aligns with GitHub's security best practices for sensitive credentials.