### PR TITLE
test: fix import path in email test file

### DIFF
--- a/__tests__/email.test.ts
+++ b/__tests__/email.test.ts
@@ -1,5 +1,5 @@
-import { env } from "@/env";
 import { describe, expect, test } from "vitest";
+import { env } from "../src/env";
 import app from "../src/index";
 
 const TIMEOUT: number = 30000;


### PR DESCRIPTION
The import path for 'env' was incorrect, causing test failures. Updated to use the correct relative path '../src/env' instead of the aliased path.